### PR TITLE
Don't overwrite sitepack on every restart

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -3,7 +3,7 @@
 # copy config
 [[ ! -e /config/WebGrab++.config.xml ]] && \
 	cp /defaults/WebGrab++.config.xml /config/
-[[ ! -e /config/ini/siteini.pack ]] && \
+[[ ! -e /config/siteini.pack ]] && \
 	cp -R /defaults/ini/siteini.pack /config/
 
 # add cron file for running webgrab+plus


### PR DESCRIPTION
The condition in `30-config` will never work, since the path is incorrect, therefore all the siteini files are overwritten on every start.

Same change as https://github.com/linuxserver/docker-webgrabplus/pull/8

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

